### PR TITLE
Add support for Python 3.13 and numpy 2

### DIFF
--- a/.github/workflows/python-package-tox.yml
+++ b/.github/workflows/python-package-tox.yml
@@ -5,25 +5,26 @@ name: Python package
 
 on:
   push:
-    branches: [ main ]
   pull_request:
-    branches: [ main ]
 
 jobs:
-  build:
+  test:
 
-    runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.5, 3.8]
+        python: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+      fail-fast: false
 
+    runs-on: ${{ matrix.python <= '3.6' && 'ubuntu-20.04' || 'ubuntu-22.04' }}
+
+    name: Test on python ${{ matrix.python }} and numpy ${{ matrix.numpyversion }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
-      - name: Install Tox and any other packages
+      - name: Install Tox
         run: pip install tox
       - name: Run Tox
         # Run tox using the version of Python in `PATH`

--- a/.github/workflows/upload_to_pypi.yml
+++ b/.github/workflows/upload_to_pypi.yml
@@ -13,9 +13,9 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v5
         name: Install Python
         with:
           python-version: '3.x'
@@ -25,9 +25,9 @@ jobs:
         # available yet which can cause the build to fail. Keep going, and upload
         # the wheels for all of the previous versions when that happens.
         continue-on-error: true
-        uses: pypa/cibuildwheel@v2.1.1
+        uses: pypa/cibuildwheel@v2.20.0
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
 
@@ -35,9 +35,9 @@ jobs:
     name: Build source distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v5
         name: Install Python
         with:
           python-version: '3.x'
@@ -48,7 +48,7 @@ jobs:
       - name: Build sdist
         run: python -m build --sdist
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           path: dist/*.tar.gz
 
@@ -57,12 +57,12 @@ jobs:
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
         with:
           name: artifact
           path: dist
 
-      - uses: pypa/gh-action-pypi-publish@v1.4.2
+      - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ requires = [
     "wheel",
     "setuptools",
     "Cython>=0.29.2",
-    "oldest-supported-numpy",
+    "oldest-supported-numpy; python_version<'3.9'",
+    "numpy>=2; python_version>='3.9'",
 ]
 build-backend = 'setuptools.build_meta'

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,6 @@ import numpy
 from setuptools import setup
 from setuptools.extension import Extension
 
-
 classifiers = [
     "Development Status :: 4 - Beta",
     "Programming Language :: Python :: 3",
@@ -49,5 +48,5 @@ setup(
     author_email="kylebarbary@gmail.com",
     ext_modules=extensions,
     install_requires=["numpy>=1.13.3"],
-    python_requires=">=3.5",
+    python_requires=">=3.6",
 )

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ extensions = [
         source_files,
         include_dirs=include_dirs,
         depends=depends_files,
-        extra_compile_args=["-std=c99"],
+        extra_compile_args=["-std=c11"],
     )
 ]
 


### PR DESCRIPTION
Hi, thanks for the very useful extinction package. We depend on it when plotting observed spectra for comparison with our models with the https://github.com/artis-mcrt/artistools package.

cpython3.13 is now in the release candidate stage, which means that the ABI is stable and wheels can now be published to PyPI. The latest version of cibuildwheel now builds py313 wheels by default.

Building extinction with the cpython 3.13 headers results in a compilation error that is resolved when updating the C standard from C99 to C11. I also updated the GitHub actions workflows to test and build wheels for python3.13.

Fixes #26 by upgrading to numpy 2 when building for cpython >= 3.9 (installation still supports numpy 1). The minimum python version increased from 3.5 to 3.6 because this is the oldest version I can get to work on GitHub actions.