### PR TITLE
Fix build matrix and PyPI upload

### DIFF
--- a/.github/workflows/upload_to_pypi.yml
+++ b/.github/workflows/upload_to_pypi.yml
@@ -72,6 +72,3 @@ jobs:
             merge-multiple: true
 
       - uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/upload_to_pypi.yml
+++ b/.github/workflows/upload_to_pypi.yml
@@ -2,7 +2,10 @@ name: Build and upload to PyPI
 
 on:
   release:
-    types: [published]
+    types: [published, edited]
+  push:
+#     branches:
+#       - main
 
 jobs:
   build_wheels:
@@ -25,10 +28,11 @@ jobs:
         # available yet which can cause the build to fail. Keep going, and upload
         # the wheels for all of the previous versions when that happens.
         continue-on-error: true
-        uses: pypa/cibuildwheel@v2.20.0
+        uses: pypa/cibuildwheel@v2.22.0
 
       - uses: actions/upload-artifact@v4
         with:
+          name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
           path: ./wheelhouse/*.whl
 
   build_sdist:
@@ -50,17 +54,22 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
+          name: cibw-sdist
           path: dist/*.tar.gz
 
   upload_pypi:
     name: Upload to PyPI
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
+    permissions:
+        id-token: write
+    if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: artifact
-          path: dist
+            pattern: cibw-*
+            path: dist
+            merge-multiple: true
 
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "wheel",
     "setuptools",
     "Cython>=0.29.2",
-    "oldest-supported-numpy; python_version<'3.9'",
+    "numpy<2; python_version<'3.9'",
     "numpy>=2; python_version>='3.9'",
 ]
 build-backend = 'setuptools.build_meta'


### PR DESCRIPTION
- GitHub Actions artefact names must now be distinct (causing failure on first attempt at 0.4.7 publishing)
- update cibuildwheel 0.22 (from 0.20).
- Change build requirement to numpy<2 for python_version<3.9