### PR TITLE
Add support for python 3.14/3.14t and increase requires-python to >= 3.8

### DIFF
--- a/.github/workflows/python-package-tox.yml
+++ b/.github/workflows/python-package-tox.yml
@@ -1,7 +1,7 @@
 # This workflow will install tox and use it to run tests.
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Python package
+name: Test
 
 on:
   push:
@@ -12,18 +12,20 @@ jobs:
 
     strategy:
       matrix:
-        python: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
       fail-fast: false
 
-    runs-on: ${{ matrix.python <= '3.6' && 'ubuntu-20.04' || 'ubuntu-22.04' }}
+    runs-on: 'ubuntu-24.04'
 
-    name: Test on python ${{ matrix.python }} and numpy ${{ matrix.numpyversion }}
+    name: Test on python ${{ matrix.python }}
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
+          allow-prereleases: true
+          check-latest: true
       - name: Install Tox
         run: pip install tox
       - name: Run Tox

--- a/.github/workflows/upload_to_pypi.yml
+++ b/.github/workflows/upload_to_pypi.yml
@@ -3,6 +3,7 @@ name: Build and upload to PyPI
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
   build_wheels:
@@ -16,16 +17,13 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v5
-        name: Install Python
-        with:
-          python-version: '3.x'
 
       - name: Build wheels
         # For very recent Python versions, wheels from e.g. numpy might not be
         # available yet which can cause the build to fail. Keep going, and upload
         # the wheels for all of the previous versions when that happens.
         continue-on-error: true
-        uses: pypa/cibuildwheel@v2.22.0
+        uses: pypa/cibuildwheel@v3.1.3
 
       - uses: actions/upload-artifact@v4
         with:
@@ -39,9 +37,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v5
-        name: Install Python
-        with:
-          python-version: '3.x'
 
       - name: Install build
         run: python -m pip install build
@@ -62,7 +57,7 @@ jobs:
         id-token: write
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
-      - uses: actions/download-artifact@v4.1.7
+      - uses: actions/download-artifact@v4
         with:
             pattern: cibw-*
             path: dist

--- a/extinction.pyx
+++ b/extinction.pyx
@@ -1,5 +1,5 @@
 #!python
-#cython: boundscheck=False, wraparound=False, initializedcheck=False, cdivision=True
+#cython: boundscheck=False, wraparound=False, initializedcheck=False, cdivision=True, freethreading_compatible=True
 
 """Interstellar dust extinction functions."""
 

--- a/setup.py
+++ b/setup.py
@@ -48,5 +48,5 @@ setup(
     author_email="kylebarbary@gmail.com",
     ext_modules=extensions,
     install_requires=["numpy>=1.13.3"],
-    python_requires=">=3.6",
+    python_requires=">=3.8",
 )


### PR DESCRIPTION
Python 3.14 release candidates are ABI stable with the upcoming final release in October, so wheels can now be published on PyPI.