### PR TITLE
Fix Read the Docs builds

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,18 @@
+version: 2
+
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.13"
+
+sphinx:
+  configuration: docs/conf.py
+  fail_on_warning: false
+
+python:
+  install:
+    - requirements: docs/rtd-pip-requirements
+    # conf.py imports extinction to read the version, and the plot directives
+    # call into it, so the compiled extension has to be installed.
+    - method: pip
+      path: .

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,15 +1,12 @@
-# -*- coding: utf-8 -*-
 #
 # build requires sphinx_rtd_theme and numpydoc.
 
 import sys
 import os
-import sphinx_rtd_theme
-import matplotlib.sphinxext.plot_directive
 import extinction
 
 # ensure that plot helper is on the path
-sys.path.insert(0, os.path.abspath(__file__))
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 # generate api directory if it doesn't already exist
 if not os.path.exists('api'):
@@ -18,8 +15,8 @@ if not os.path.exists('api'):
 # -- General configuration ------------------------------------------------
 
 intersphinx_mapping = {
-    'python': ('http://docs.python.org/', None),
-    'numpy': ('http://docs.scipy.org/doc/numpy/', None)}
+    'python': ('https://docs.python.org/3/', None),
+    'numpy': ('https://numpy.org/doc/stable/', None)}
 
 extensions = [
     'sphinx.ext.autodoc',
@@ -27,12 +24,12 @@ extensions = [
     'sphinx.ext.intersphinx',
     'sphinx.ext.mathjax',
     'numpydoc',
-    matplotlib.sphinxext.plot_directive.__name__]
+    'matplotlib.sphinxext.plot_directive']
 
 numpydoc_show_class_members = False
 autosummary_generate = True
 autoclass_content = "class"
-autodoc_default_flags = ["members", "no-special-members"]
+autodoc_default_options = {"members": True}
 
 # The suffix of source filenames.
 source_suffix = '.rst'
@@ -72,7 +69,6 @@ pygments_style = 'sphinx'
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 html_theme = "sphinx_rtd_theme"
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,9 +17,9 @@ Using pip (requires a C compiler)::
 
     pip install extinction
 
-Extinction depends on numpy and scipy.
+Extinction depends on numpy.
 
-**Development version / source code:** http://github.com/kbarbary/extinction
+**Development version / source code:** https://github.com/sncosmo/extinction
 
 
 Usage

--- a/docs/rtd-pip-requirements
+++ b/docs/rtd-pip-requirements
@@ -1,5 +1,4 @@
-numpy
+sphinx
+sphinx_rtd_theme
 numpydoc
-scipy
-Cython
 matplotlib


### PR DESCRIPTION
The published documentation at extinction.readthedocs.io has been stale for over a year. Read the Docs reports the last successful `latest` build on 2024-12-16 and the last successful `stable` build in September 2021, so visitors following the README link have been reading 2021-era docs.

The cause is the missing config file: Read the Docs has required a `.readthedocs.yaml` in the repository since 2023, and builds fail without one. This adds it, installing the package itself as well as the docs requirements, since `conf.py` imports `extinction` for the version and the plot directives call into the compiled extension.

Cleanups to the Sphinx config while here, none of which were causing the failure:

- Drop the deprecated `get_html_theme_path()` call, which emits a warning on current `sphinx_rtd_theme` and is no longer needed.
- Replace `autodoc_default_flags` (removed in Sphinx 4, so currently a no-op) with `autodoc_default_options`.
- Update the intersphinx URLs — `http://docs.scipy.org/doc/numpy/` no longer resolves.
- Fix the `sys.path` entry for the plot helper, which pointed at `conf.py` itself rather than its directory.
- Drop scipy, which isn't a dependency: the bundled spline C code exists precisely so scipy isn't required, per the comment in `extinction.pyx`.
- Point the source link at the `sncosmo` org rather than `kbarbary`.

Verified locally against Sphinx 9.1 with a fresh environment built from `docs/rtd-pip-requirements`: the build succeeds and all three plot directives render. (The one remaining warning, an autosummary stub for `extinction.fitzpatrick99`, is an artifact of the case-insensitive macOS filesystem colliding with `extinction.Fitzpatrick99` — it does not occur on RTD's Linux builders.)

One thing to check after merging: the RTD project may need its webhook reconnected if it stopped receiving events, and `stable` will only update once a new tag is built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)