### PR TITLE
Modernise packaging and CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/python-package-tox.yml
+++ b/.github/workflows/python-package-tox.yml
@@ -19,9 +19,9 @@ jobs:
 
     name: Test on python ${{ matrix.python }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python }}
           allow-prereleases: true

--- a/.github/workflows/upload_to_pypi.yml
+++ b/.github/workflows/upload_to_pypi.yml
@@ -14,9 +14,9 @@ jobs:
         os: [ubuntu-latest, ubuntu-latest-arm, windows-latest, macos-latest]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
 
       - name: Build wheels
         # For very recent Python versions, wheels from e.g. numpy might not be
@@ -25,7 +25,7 @@ jobs:
         continue-on-error: true
         uses: pypa/cibuildwheel@v4.2.0
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
           path: ./wheelhouse/*.whl
@@ -34,9 +34,9 @@ jobs:
     name: Build source distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
 
       - name: Install build
         run: python -m pip install build
@@ -44,7 +44,7 @@ jobs:
       - name: Build sdist
         run: python -m build --sdist
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: cibw-sdist
           path: dist/*.tar.gz
@@ -57,7 +57,7 @@ jobs:
         id-token: write
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
             pattern: cibw-*
             path: dist

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,3 +5,5 @@ include pyproject.toml
 include extinction.pyx
 include extern/bs.*
 include extern/bsplines.pxi
+include test.py
+recursive-include testdata *

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ extinction
 *Fast interstellar dust extinction laws in Python*
 
 
-![Build Status](https://github.com/kbarbary/extinction/workflows/Test/badge.svg)
+[![Test](https://github.com/sncosmo/extinction/actions/workflows/python-package-tox.yml/badge.svg)](https://github.com/sncosmo/extinction/actions/workflows/python-package-tox.yml)
 [![PyPI](https://img.shields.io/pypi/v/extinction.svg?style=flat-square)](https://pypi.python.org/pypi/extinction)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.804967.svg)](https://doi.org/10.5281/zenodo.804967)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,47 @@
 [build-system]
 requires = [
-    "wheel",
-    "setuptools",
-    "Cython>=0.29.2",
+    "setuptools>=77",
+    "Cython>=3",
     "numpy>=2",
 ]
-build-backend = 'setuptools.build_meta'
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "extinction"
+description = "Fast interstellar dust extinction laws"
+readme = "README.md"
+license = "MIT"
+license-files = ["LICENSE"]
+authors = [{ name = "Kyle Barbary", email = "kylebarbary@gmail.com" }]
+requires-python = ">=3.9"
+# Wheels are built against numpy 2, which stays ABI compatible back to 1.19.3.
+dependencies = ["numpy>=1.19.3"]
+dynamic = ["version"]
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Science/Research",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3.15",
+    "Programming Language :: Python :: Free Threading :: 3 - Stable",
+    "Topic :: Scientific/Engineering :: Astronomy",
+]
+
+[project.urls]
+Homepage = "https://github.com/sncosmo/extinction"
+Documentation = "https://extinction.readthedocs.io"
+Source = "https://github.com/sncosmo/extinction"
+
+# extinction is a single compiled module, so disable package auto-discovery,
+# which would otherwise trip over the docs/, extern/ and testdata/ directories.
+[tool.setuptools]
+py-modules = []
+
+[tool.cibuildwheel]
+test-requires = "pytest"
+test-command = "pytest {project}/test.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,10 @@
 [build-system]
 requires = [
     "setuptools>=77",
-    "Cython>=3",
+    # 3.1 is the first release that honours the freethreading_compatible
+    # directive in extinction.pyx; earlier versions silently ignore it and
+    # emit a module that re-enables the GIL on free-threaded interpreters.
+    "Cython>=3.1",
     "numpy>=2",
 ]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -4,18 +4,12 @@ import re
 import sys
 
 import numpy
+from Cython.Build import cythonize
 from setuptools import setup
 from setuptools.extension import Extension
 
-classifiers = [
-    "Development Status :: 4 - Beta",
-    "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: MIT License",
-    "Topic :: Scientific/Engineering :: Astronomy",
-    "Intended Audience :: Science/Research",
-]
-
-# Synchronize version from code.
+# Everything except the version and the extension itself lives in
+# pyproject.toml. Synchronize the version from code.
 fname = "extinction.pyx"
 version = re.findall(r"__version__ = \"(.*?)\"", open(fname).read())[0]
 
@@ -26,27 +20,21 @@ depends_files = [
     os.path.join("extern", "bsplines.pxi")
 ]
 include_dirs = [numpy.get_include(), "extern"]
+
+# MSVC does not understand -std=c11 and only warns about it.
+extra_compile_args = [] if sys.platform == "win32" else ["-std=c11"]
+
 extensions = [
     Extension(
         "extinction",
         source_files,
         include_dirs=include_dirs,
         depends=depends_files,
-        extra_compile_args=["-std=c11"],
+        extra_compile_args=extra_compile_args,
     )
 ]
 
 setup(
-    name="extinction",
     version=version,
-    description="Fast interstellar dust extinction laws",
-    long_description="documentation: http://extinction.readthedocs.io",
-    license="MIT",
-    classifiers=classifiers,
-    url="http://github.com/kbarbary/extinction",
-    author="Kyle Barbary",
-    author_email="kylebarbary@gmail.com",
-    ext_modules=extensions,
-    install_requires=["numpy>=1.13.3"],
-    python_requires=">=3.9",
+    ext_modules=cythonize(extensions, language_level=3),
 )

--- a/test.py
+++ b/test.py
@@ -7,6 +7,11 @@ from numpy.testing import assert_allclose
 
 import extinction
 
+# Resolve test data relative to this file so the suite can be run from any
+# working directory, including against an installed wheel.
+TESTDATA_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                            'testdata')
+
 
 def test_ccm89():
     # NOTE: Test is only to precision of 0.016 because there is a discrepancy
@@ -136,7 +141,7 @@ def test_fitzpatrick99_idl():
     """Test that result matches implementation in IDL procedure FM_UNRED"""
 
     for r_v in (2.3, 3.1, 4.0, 5.3):
-        fname = os.path.join('testdata', 'fm_unred_{:3.1f}.dat'.format(r_v))
+        fname = os.path.join(TESTDATA_DIR, 'fm_unred_{:3.1f}.dat'.format(r_v))
         wave, a_lambda_ref = np.loadtxt(fname, unpack=True)
         a_lambda = extinction.Fitzpatrick99(r_v)(wave, 1.0)
         assert_allclose(a_lambda, a_lambda_ref, rtol=0.00005)


### PR DESCRIPTION
Follow-up to #35, #36 and #37, covering the remaining modernisation items.

## Packaging metadata

Metadata moves to a PEP 621 `[project]` table. Beyond tidiness this has a concrete effect: cibuildwheel reads `requires-python` from `[project]` to decide which interpreters to target, and with the metadata only in `setup.py` it could not — so the `>= 3.9` bump in #35 had no actual influence on the build. `setup.py` is now just the version and the extension.

- **numpy floor corrected** to `>= 1.19.3`. Wheels are built against numpy 2, which is ABI compatible back to 1.19.3, so the previous `>= 1.13.3` understated the real runtime requirement and would let pip resolve an installation that cannot import.
- **README as `long_description`**, so the PyPI page renders the readme instead of the bare string `documentation: http://extinction.readthedocs.io`.
- **Classifiers** for Python 3.9–3.15 plus `Free Threading :: 3 - Stable`. All validated against `trove-classifiers`; an unknown classifier is rejected at upload time.
- **License** as an SPDX expression with `license-files`, which is why the `License ::` classifier is gone — setuptools rejects having both.
- `py-modules = []` disables package auto-discovery, which would otherwise trip over `docs/`, `extern/` and `testdata/` once `[project]` exists.

## Build correctness

- **Cythonize explicitly** with `language_level=3`, and require `Cython >= 3`. The build previously relied on setuptools' implicit `.pyx` handling, and the old `Cython >= 0.29.2` floor allowed a Cython whose language level defaults to **2**.
- **Stop passing `-std=c11` to MSVC**, which does not understand the flag and only warns.

## Testing

- **Wheels are now tested at build time** via `test-command`. Every wheel published so far was uploaded without ever being imported.
- **`test.py` and `testdata/` ship in the sdist**, so conda-forge and distro packagers can run the suite; the sdist previously contained neither. Test data is now resolved relative to `test.py` rather than the working directory, which is what makes it runnable against an installed wheel.

I did not expand the tox matrix to macOS and Windows: the cibuildwheel test command now exercises the compiled extension on every platform and interpreter at build time, which covers the same ground without tripling the per-push CI cost.

## CI hygiene

Actions bumped off Node 20, which GitHub has deprecated and was warning about on every run (checkout v7, setup-python v7, upload-artifact v7, download-artifact v8), plus a dependabot config so the pins stay current. URL metadata and the README badge now point at `sncosmo` rather than `kbarbary`; the badge was using the old workflow-name URL form and pointing at the wrong org.

## Verification

Locally, against Python 3.13:

- `python -m build` produces both sdist and wheel.
- Wheel metadata is correct — `Requires-Python: >=3.9`, `Requires-Dist: numpy>=1.19.3`, `License-Expression: MIT`, markdown description, all classifiers.
- The sdist installs from source (`pip install --no-binary`) and imports.
- All 9 tests pass against the **installed wheel** from an unrelated working directory, with `extinction` resolving to the installed `.so` rather than the source tree — the case the new `test-command` depends on.

## Two things to look at

1. **`Development Status` is now `5 - Production/Stable`**, up from `4 - Beta`. That is an editorial judgement about the project rather than a technical fix, and it sits a little oddly against a sub-1.0 version number — easy to revert if you disagree.
2. **`continue-on-error: true` on the cibuildwheel step now also swallows test failures.** It exists so a missing upstream numpy wheel for a brand-new Python does not sink the whole release, which is still reasonable, but with tests attached it means a genuine regression would quietly drop that platform's wheels rather than failing the run. Worth deciding separately whether to narrow it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)