### PR TITLE
Use ubuntu-24.04 and ubuntu-24.04-arm for all Ubuntu runners

### DIFF
--- a/.github/workflows/python-package-tox.yml
+++ b/.github/workflows/python-package-tox.yml
@@ -15,7 +15,7 @@ jobs:
         python: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "3.15", "3.15t"]
       fail-fast: false
 
-    runs-on: 'ubuntu-latest'
+    runs-on: 'ubuntu-24.04'
 
     name: Test on python ${{ matrix.python }}
     steps:

--- a/.github/workflows/upload_to_pypi.yml
+++ b/.github/workflows/upload_to_pypi.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, ubuntu-latest-arm, windows-latest, macos-latest]
+        os: [ubuntu-24.04, ubuntu-24.04-arm, windows-latest, macos-latest]
 
     steps:
       - uses: actions/checkout@v4
@@ -32,7 +32,7 @@ jobs:
 
   build_sdist:
     name: Build source distribution
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 
@@ -52,7 +52,7 @@ jobs:
   upload_pypi:
     name: Upload to PyPI
     needs: [build_wheels, build_sdist]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
         id-token: write
     if: startsWith(github.ref, 'refs/tags/v')


### PR DESCRIPTION
`ubuntu-latest-arm`, currently on `main`, is not a valid GitHub-hosted runner label, so the aarch64 wheel job never gets scheduled and the release workflow cannot complete.

Unlike macOS, Ubuntu ARM has no `-latest` alias. The [runner-images README](https://github.com/actions/runner-images) lists exactly three Ubuntu ARM labels: `ubuntu-22.04-arm`, `ubuntu-24.04-arm` and `ubuntu-26.04-arm`.

This pins every Ubuntu runner to an explicit 24.04 label — the wheel matrix, the sdist job, the PyPI upload job, and the tox test workflow — so x86_64 and aarch64 build on the same release and the image cannot shift underneath us the way `ubuntu-latest` can.

### Evidence for the breakage

In [run 31334533863](https://github.com/sncosmo/extinction/actions/runs/31334533863), every other job was assigned a runner within seconds and three finished, while the ARM job sat unassigned:

```
Build sdist:                       completed   runner=GitHub Actions 1000000471
Build wheels on ubuntu-latest:     completed   runner=GitHub Actions 1000000472
Build wheels on macos-latest:      completed   runner=GitHub Actions 1000000473
Build wheels on windows-latest:    in_progress runner=GitHub Actions 1000000470
Build wheels on ubuntu-latest-arm: queued      runner=          <-- never assigned
```

By contrast `ubuntu-24.04-arm` was assigned a runner and completed in 5m31s in [run 31332878299](https://github.com/sncosmo/extinction/actions/runs/31332878299) on this same repository, so ARM capacity is available — it was the label that was wrong.

### Why 24.04 rather than 26.04

26.04 was tried first and works for the wheel jobs, but GitHub still marks both 26.04 images as *preview*, and `setup-python` has no Python 3.9 build in its manifest for 26.04 now that 3.9 is end of life — the 3.9 test job failed immediately with `Failed to resolve version ~3.9.0-0 from manifest` while all eight other versions passed. Since the package supports 3.9, 24.04 keeps the whole matrix on one generally-available image with no special cases.

Worth merging ahead of #38, which inherits the broken label from `main` and will need a rebase after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)