### PR TITLE
Pin the numpy C API level

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,12 +26,17 @@ include_dirs = [numpy.get_include(), "extern"]
 # MSVC does not understand -std=c11 and only warns about it.
 extra_compile_args = [] if sys.platform == "win32" else ["-std=c11"]
 
+# Pin the numpy C API level, so that a future numpy removing an already
+# deprecated API is a compile error here rather than a surprise at runtime.
+define_macros = [("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")]
+
 extensions = [
     Extension(
         "extinction._extinction",
         source_files,
         include_dirs=include_dirs,
         depends=depends_files,
+        define_macros=define_macros,
         extra_compile_args=extra_compile_args,
     )
 ]


### PR DESCRIPTION
Adds `NPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION` to the extension's `define_macros`.

Without it the extension compiles against whatever numpy currently exposes, including APIs numpy has already deprecated. That means a future numpy removing one of them shows up as a broken build — or a broken wheel — at whatever moment numpy happens to release. With the guard, using a deprecated API becomes a compile error here, on our schedule rather than theirs.

### Result

This was the change most likely to fail outright, since enabling the guard surfaces any deprecated usage as an error. It doesn't: **the code uses no deprecated numpy API**.

The define is visibly applied to both translation units:

```
clang ... -DNPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION ... -c extern/bs.c
clang ... -DNPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION ... -c src/extinction/_extinction.c
```

and the build produces no new warnings or errors — including from the Cython-generated C, which is the part most likely to reach for older numpy APIs.

`NPY_1_7_API_VERSION` is the level numpy documents for this purpose; it is the *floor* the code is held to, not a cap on the numpy version, and builds continue to use numpy 2 headers as before.

### Verification

- Wheel builds cleanly with the guard applied to both C sources.
- 9/9 tests pass against the resulting wheel from an unrelated working directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)